### PR TITLE
Remove unused keyBy

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { isString, keyBy } from 'lodash';
+import { isString } from 'lodash';
 
 import countriesRaw from './countries';
 import { Country, Maybe, Province } from './types';


### PR DESCRIPTION
Remove the unused import of keyBy from lodash since it triggers some TS related errors in my project.

On another note, I do think the lib should be compiled into JS and export the type declarations instead - would probably offer better compat with other projects

Thanks for the work on this lib!