### PR TITLE
Add alpha3 to the country shortname search

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ import { getCountryByName } from 'node-countries'
 
 Return the matched country object, else null (alias: `findCountryByName`)
 
-### getCountryByNameOrShortName(name or short name (alpha2), [useAlias])
+### getCountryByNameOrShortName(name or short name (alpha2, alpha3), [useAlias])
 
 ```javascript
 import { getCountryByNameOrShortName } from 'node-countries'

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -156,16 +156,24 @@ describe('Unit Testing ->', () => {
           expect(getCountryByNameOrShortName('Guinea-Bissau')).to.eql(GuineaBissau);
         });
 
-        it('should return country object when find it using short name', () => {
+        it('should return country object when find it using alpha2', () => {
           expect(getCountryByNameOrShortName('GW')).to.eql(GuineaBissau);
+        });
+
+        it('should return country object when find it using alpha3', () => {
+          expect(getCountryByNameOrShortName('GNB')).to.eql(GuineaBissau);
         });
 
         it('should return country object by ignoring case', () => {
           expect(getCountryByNameOrShortName('GuiNea-BisSau')).to.eql(GuineaBissau);
         });
 
-        it('should return country object by ignoring case using short name', () => {
+        it('should return country object by ignoring case using alpha2', () => {
           expect(getCountryByNameOrShortName('Gw')).to.eql(GuineaBissau);
+        });
+
+        it('should return country object by ignoring case using alpha3', () => {
+          expect(getCountryByNameOrShortName('GnB')).to.eql(GuineaBissau);
         });
 
         it('should return `null` when searching alias with no useAlias parameter', () => {
@@ -180,16 +188,24 @@ describe('Unit Testing ->', () => {
           expect(getCountryByNameOrShortName('Guinea Bissau', true)).to.eql(GuineaBissau);
         });
 
-        it('should return `null` when searching alias with useAlias parameter `true` using short name', () => {
+        it('should return `null` when searching alias with useAlias parameter `true` using alpha2', () => {
           expect(getCountryByNameOrShortName('GW', true)).to.eql(GuineaBissau);
+        });
+
+        it('should return `null` when searching alias with useAlias parameter `true` using alpha3', () => {
+          expect(getCountryByNameOrShortName('GNB', true)).to.eql(GuineaBissau);
         });
 
         it('should return `null` by ignoring case when searching alias with useAlias parameter `true`', () => {
           expect(getCountryByNameOrShortName('GuiNea BisSau', true)).to.eql(GuineaBissau);
         });
 
-        it('should return `null` by ignoring case when searching alias with useAlias parameter `true` using short name', () => {
+        it('should return `null` by ignoring case when searching alias with useAlias parameter `true` using alpha2', () => {
           expect(getCountryByNameOrShortName('Gw', true)).to.eql(GuineaBissau);
+        });
+
+        it('should return `null` by ignoring case when searching alias with useAlias parameter `true` using alpha3', () => {
+          expect(getCountryByNameOrShortName('GnB', true)).to.eql(GuineaBissau);
         });
 
         it('should return country object when searching alias with useAlias parameter `true` and country has no province', () => {
@@ -210,16 +226,24 @@ describe('Unit Testing ->', () => {
           expect(findCountryByNameOrShortName('Guinea-Bissau')).to.eql(GuineaBissau);
         });
 
-        it('should return country object when find it using short name', () => {
+        it('should return country object when find it using alpha2', () => {
           expect(findCountryByNameOrShortName('GW')).to.eql(GuineaBissau);
+        });
+
+        it('should return country object when find it using alpha3', () => {
+          expect(findCountryByNameOrShortName('GNB')).to.eql(GuineaBissau);
         });
 
         it('should return country object when find it by ignoring case', () => {
           expect(findCountryByNameOrShortName('GuiNea-BisSau')).to.eql(GuineaBissau);
         });
 
-        it('should return country object when find it by ignoring case using short name', () => {
+        it('should return country object when find it by ignoring case using alpha2', () => {
           expect(findCountryByNameOrShortName('Gw')).to.eql(GuineaBissau);
+        });
+
+        it('should return country object when find it by ignoring case using alpha3', () => {
+          expect(findCountryByNameOrShortName('GnB')).to.eql(GuineaBissau);
         });
 
         it('should return `null` when searching alias with no useAlias parameter', () => {
@@ -234,16 +258,24 @@ describe('Unit Testing ->', () => {
           expect(findCountryByNameOrShortName('Guinea Bissau', true)).to.eql(GuineaBissau);
         });
 
-        it('should return `null` when searching alias with useAlias parameter `true` using short name', () => {
+        it('should return `null` when searching alias with useAlias parameter `true` using alpha2', () => {
           expect(findCountryByNameOrShortName('GW', true)).to.eql(GuineaBissau);
+        });
+
+        it('should return `null` when searching alias with useAlias parameter `true` using alpha3', () => {
+          expect(findCountryByNameOrShortName('GNB', true)).to.eql(GuineaBissau);
         });
 
         it('should return `null` by ignoring case when searching alias with useAlias parameter `true`', () => {
           expect(findCountryByNameOrShortName('GuiNea BisSau', true)).to.eql(GuineaBissau);
         });
 
-        it('should return `null` by ignoring case when searching alias with useAlias parameter `true` using short name', () => {
+        it('should return `null` by ignoring case when searching alias with useAlias parameter `true` using alpha2', () => {
           expect(findCountryByNameOrShortName('Gw', true)).to.eql(GuineaBissau);
+        });
+
+        it('should return `null` by ignoring case when searching alias with useAlias parameter `true` using alpha3', () => {
+          expect(findCountryByNameOrShortName('GnB', true)).to.eql(GuineaBissau);
         });
 
         it('should return country object when searching alias with useAlias parameter `true` and country has no alias', () => {

--- a/index.ts
+++ b/index.ts
@@ -37,7 +37,7 @@ export function getCountryByName(name?: Maybe<string>, useAlias?: Maybe<boolean>
 /**
  * Find the country object of the given country name or short name
  *
- * @param {String}  name              country name or short name (alpha2)
+ * @param {String}  name              country name or short name (alpha2, alpha3)
  * @param {Boolean} [useAlias]        use alias flag, default `false`
  * @return {Object} country           country object
  */
@@ -53,6 +53,7 @@ export function getCountryByNameOrShortName(
         return (
           country.name.toUpperCase() === name.toUpperCase() ||
           country.alpha2.toUpperCase() === name.toUpperCase() ||
+          country.alpha3.toUpperCase() === name.toUpperCase() ||
           (country.alias || []).find(function (alias) {
             return alias.toUpperCase() === name.toUpperCase();
           })
@@ -60,7 +61,8 @@ export function getCountryByNameOrShortName(
       }
       return (
         country.name.toUpperCase() === name.toUpperCase() ||
-        country.alpha2.toUpperCase() === name.toUpperCase()
+        country.alpha2.toUpperCase() === name.toUpperCase() ||
+        country.alpha3.toUpperCase() === name.toUpperCase()
       );
     }) ?? null
   );


### PR DESCRIPTION
## Notes

- For country search by "short name" only `alpha2` was been used so adding `alpha3` to the search name too